### PR TITLE
fix: resolution of relative paths in `package_config.json`

### DIFF
--- a/flutter_package/pubspec.yaml
+++ b/flutter_package/pubspec.yaml
@@ -4,8 +4,10 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  expect_error:
+    path: ..
   flutter:
     sdk: flutter

--- a/lib/src/expect_error.dart
+++ b/lib/src/expect_error.dart
@@ -29,27 +29,21 @@ class Library {
     required String path,
     required String packageRoot,
   }) async {
-    final packageRootUri = Uri.file(Directory(packageRoot).absolute.path);
-
-    final packageConfigString = File(
-      _path.join(packageRoot, '.dart_tool', 'package_config.json'),
-    ).readAsStringSync();
-
+    final packageConfigFile =
+        File(_path.join(packageRoot, '.dart_tool', 'package_config.json'));
     final packageConfig = PackageConfig.parseString(
-      packageConfigString,
-      packageRootUri,
+      packageConfigFile.readAsStringSync(),
+      packageConfigFile.absolute.uri,
     );
-
-    final tempTestFilePath = _path.join(packageRoot, path);
 
     return Library(
       packageName: packageName,
-      path: _path.normalize(tempTestFilePath).replaceAll(r'\', '/'),
+      path: _path.normalize(path).replaceAll(r'\', '/'),
       packageConfig: packageConfig,
     );
   }
 
-  /// Decode the [StackTrace] to try and extract informations about the current
+  /// Decode the [StackTrace] to try and extract information about the current
   /// library.
   ///
   /// This should only be used within the "main" of a test file.
@@ -100,7 +94,7 @@ class Code {
   /// The file content
   final String code;
 
-  /// Metadatas about the file
+  /// Metadata about the file
   final Library library;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ version: 1.0.4
 repository: https://github.com/rrousselGit/expect_error
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: '>=3.0.0 <=5.0.0'
   build_test: ^2.1.3
   collection: ^1.15.0
   package_config: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A testing utility for checking compilation errors
 version: 1.0.4
 repository: https://github.com/rrousselGit/expect_error
 
-environment: 
+environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=3.0.0 <=5.0.0'
+  analyzer: '>=4.0.0 <6.0.0'
   build_test: ^2.1.3
   collection: ^1.15.0
   package_config: ^2.0.0

--- a/test/compiles_test.dart
+++ b/test/compiles_test.dart
@@ -33,6 +33,22 @@ void main() {
     expectTestPassed(liveTest);
   });
 
+  test('supports relative path dependencies', () async {
+    final library = await Library.custom(
+      packageName: 'example',
+      path: 'lib/foo.dart',
+      packageRoot: 'flutter_package',
+    );
+
+    final liveTest = await runTestBody(() async {
+      await expectLater(library.withCode('''
+import 'package:expect_error/expect_error.dart';
+'''), compiles);
+    });
+
+    expectTestPassed(liveTest);
+  });
+
   test('can use relative imports based on the file location', () async {
     final liveTest = await runTestBody(() async {
       await expectLater(library.withCode('''


### PR DESCRIPTION
`PackageConfig.parseString` should be given the `URI` of the `package_config.json` to parse, otherwise relative paths in `package_config.json` will be resolved into absolute paths incorrectly.

This is blocking https://github.com/firebase/flutterfire/pull/10046.