### PR TITLE
fix: using multiple `compiles` in a single test

### DIFF
--- a/lib/src/expect_error.dart
+++ b/lib/src/expect_error.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/source/source_range.dart';
+import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_test/build_test.dart';
 import 'package:collection/collection.dart';
 import 'package:package_config/package_config.dart';
@@ -200,6 +201,7 @@ ${code.code}''';
     {'${code.library.packageName}|${code.library.path}': source},
     (r) => r.findLibraryByName('main'),
     packageConfig: code.library.packageConfig,
+    resolvers: AnalyzerResolvers(),
   );
 
   final errorResult = await main!.session.getErrors(

--- a/lib/src/expect_error.dart
+++ b/lib/src/expect_error.dart
@@ -197,15 +197,18 @@ ${code.code}''';
     return false;
   }
 
+  // '.dart' has the length 5
+  final tempFileName =
+      '${code.library.path.substring(0, code.library.path.length - 5)}_${source.hashCode}.dart';
+
   final main = await resolveSources(
-    {'${code.library.packageName}|${code.library.path}': source},
+    {'${code.library.packageName}|$tempFileName': source},
     (r) => r.findLibraryByName('main'),
     packageConfig: code.library.packageConfig,
-    resolvers: AnalyzerResolvers(),
   );
 
   final errorResult = await main!.session.getErrors(
-    '/${code.library.packageName}/${code.library.path}',
+    '/${code.library.packageName}/$tempFileName',
   ) as ErrorsResult;
   final criticalErrors = errorResult.errors
       .where((element) => element.severity == Severity.error)

--- a/lib/src/expect_error.dart
+++ b/lib/src/expect_error.dart
@@ -4,7 +4,6 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/source/source_range.dart';
-import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_test/build_test.dart';
 import 'package:collection/collection.dart';
 import 'package:package_config/package_config.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   analyzer: '>=4.0.0 <6.0.0'
+  build_resolvers: ^2.1.0
   build_test: ^2.1.3
   collection: ^1.15.0
   package_config: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,10 @@ version: 1.0.5
 repository: https://github.com/rrousselGit/expect_error
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=4.0.0 <6.0.0'
-  build_resolvers: ^2.1.0
+  analyzer: ">=4.0.0 <6.0.0"
   build_test: ^2.1.3
   collection: ^1.15.0
   package_config: ^2.0.0


### PR DESCRIPTION
Fix #8 

By default, all `resolveSources` calls use the same `AnalyzerResolvers`. Although I didn't deep dive into the definition of `AnalyzerResolvers`, I assume, they keep the loaded 'files' in memory.

However... The new tests failed, and now they succeed.